### PR TITLE
Only use on Windows

### DIFF
--- a/rabbit_shell/data/data.py
+++ b/rabbit_shell/data/data.py
@@ -37,8 +37,9 @@ TIMEOUT = 12
 
 # paths
 CLIENT_NAME = "client"
-WIN_STARTUP_PATH = f"C:\\Users\\{os.getlogin()}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
-DEFAULT_ICON = "data\\images\\logoicon.ico"
+if os.name == 'nt':
+    WIN_STARTUP_PATH = f"C:\\Users\\{os.getlogin()}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
+    DEFAULT_ICON = "data\\images\\logoicon.ico"
 
 API_LINK = {
     "ipify": "api.ipify.org"


### PR DESCRIPTION
Issue when running on *nix

```bash
[...]
    from .data import data, about, basic
  File "/nix/store/9arpm75dsjvjvza5kz2yaqk3rhv5g6zp-rabbit-shell-2.0/lib/python3.9/site-packages/rabbit_shell/data/data.py", line 40, in <module>
    WIN_STARTUP_PATH = f"C:\\Users\\{os.getlogin()}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
OSError: [Errno 6] No such device or address
```